### PR TITLE
Awaiter for task handle

### DIFF
--- a/async_coro/include/async_coro/base_handle.h
+++ b/async_coro/include/async_coro/base_handle.h
@@ -242,6 +242,22 @@ class base_handle {
     return _execution_queue;
   }
 
+  /**
+   * @brief Continues the execution of a coroutine.
+   * @details For internal use. This will either execute the coroutine immediately if the current
+   * thread is suitable, or schedule it for later execution.
+   * @param handle_impl The handle of the coroutine to continue.
+   */
+  void continue_execution();
+
+  /**
+   * @brief Schedules a coroutine for continued execution on its assigned thread.
+   * @details For internal use. Unlike `continue_execution`, this method always schedules
+   * the coroutine for later execution without attempting to run it immediately.
+   * @param handle_impl The handle of the coroutine to schedule.
+   */
+  void plan_continue_execution();
+
  protected:
   // returns true if continuation was executed
   virtual bool execute_continuation() = 0;

--- a/async_coro/include/async_coro/coroutine_suspender.h
+++ b/async_coro/include/async_coro/coroutine_suspender.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <async_coro/config.h>
+
+#include <atomic>
+#include <cstdint>
+#include <utility>
+
+namespace async_coro {
+
+class base_handle;
+
+/// @brief Manages the suspension and resumption of a coroutine based on a suspend count.
+///
+/// The `coroutine_suspender` class is responsible for controlling the suspension state of a coroutine.
+/// It tracks the number of outstanding suspensions and resumes the coroutine when the suspend count reaches zero.
+/// This class is move-only and not copyable.
+///
+/// @note The suspend count is managed atomically. The coroutine is resumed either immediately or scheduled
+/// for execution on any thread, depending on which method is called. Method `try_to_continue_immediately` should be called at least once.
+///
+/// @see try_to_continue_on_any_thread
+/// @see try_to_continue_immediately
+class coroutine_suspender {
+ public:
+  coroutine_suspender() noexcept {}
+  coroutine_suspender(base_handle& handle, std::uint32_t suspend_count) noexcept
+      : _handle(&handle),
+        _suspend_count(suspend_count) {
+    // try_to_continue_on_same_thread should be called at least once
+    ASYNC_CORO_ASSERT(suspend_count > 0);
+  }
+
+  coroutine_suspender(const coroutine_suspender&) = delete;
+  coroutine_suspender(coroutine_suspender&& other) noexcept
+      : _handle(std::exchange(other._handle, nullptr)),
+        _suspend_count(other._suspend_count.exchange(0, std::memory_order::relaxed)) {
+  }
+
+  coroutine_suspender& operator=(const coroutine_suspender&) = delete;
+
+  coroutine_suspender& operator=(coroutine_suspender&& other) noexcept {
+    ASYNC_CORO_ASSERT(_suspend_count.load(std::memory_order::relaxed) == 0);
+
+    _handle = std::exchange(other._handle, nullptr);
+    _suspend_count.store(other._suspend_count.exchange(0, std::memory_order::relaxed), std::memory_order::relaxed);
+
+    return *this;
+  }
+
+  ~coroutine_suspender() noexcept = default;
+
+  // Decrements suspend_count and if it zero schedules coroutine.
+  void try_to_continue_on_any_thread();
+
+  // Decrements suspend_count and if it zero schedules coroutine.
+  // Should be called only on the thread where this object was created.
+  // This method should be called at least once.
+  void try_to_continue_immediately();
+
+ private:
+  base_handle* _handle = nullptr;
+  std::atomic<std::uint32_t> _suspend_count{0};
+  bool _was_continued_immediately{false};
+};
+
+}  // namespace async_coro

--- a/async_coro/include/async_coro/execution_system.h
+++ b/async_coro/include/async_coro/execution_system.h
@@ -227,6 +227,11 @@ class execution_system : public i_execution_system {
   /** @brief Type alias for the task queue using atomic_queue */
   using tasks = atomic_queue<task_function>;
 
+#if defined _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4324)
+#endif
+
   /**
    * @brief Data structure containing information for each worker thread
    *
@@ -249,6 +254,10 @@ class execution_system : public i_execution_system {
     /** @brief Num empty worker loops to do before going to sleep on notifier */
     std::size_t num_loops_before_sleep = 0;
   };
+
+#if defined _MSC_VER
+#pragma warning(pop)
+#endif
 
   /**
    * @brief Data structure for managing a single execution queue

--- a/async_coro/include/async_coro/internal/await_callback.h
+++ b/async_coro/include/async_coro/internal/await_callback.h
@@ -41,9 +41,9 @@ struct await_callback {
           return;
         }
         if (_suspended.load(std::memory_order::acquire)) {
-          handle.get_scheduler().continue_execution(handle);
+          handle.continue_execution();
         } else {
-          handle.get_scheduler().plan_continue_execution(handle);
+          handle.plan_continue_execution();
         }
       }
     });

--- a/async_coro/include/async_coro/internal/await_callback.h
+++ b/async_coro/include/async_coro/internal/await_callback.h
@@ -24,6 +24,11 @@ struct await_callback {
 
   bool await_ready() const noexcept { return false; }
 
+#if defined _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4702)
+#endif
+
   template <typename U>
     requires(std::derived_from<U, base_handle>)
   void await_suspend(std::coroutine_handle<U> h) {
@@ -39,6 +44,10 @@ struct await_callback {
 
     _suspension.try_to_continue_immediately();
   }
+
+#if defined _MSC_VER
+#pragma warning(pop)
+#endif
 
   void await_resume() const noexcept {}
 

--- a/async_coro/include/async_coro/internal/await_when_all.h
+++ b/async_coro/include/async_coro/internal/await_when_all.h
@@ -62,9 +62,9 @@ struct await_when_all {
 
           base_handle& handle = h.promise();
           if (_suspended.load(std::memory_order::acquire)) {
-            handle.get_scheduler().continue_execution(handle);
+            handle.continue_execution();
           } else {
-            handle.get_scheduler().plan_continue_execution(handle);
+            handle.plan_continue_execution();
           }
         }
       });

--- a/async_coro/include/async_coro/internal/await_when_any.h
+++ b/async_coro/include/async_coro/internal/await_when_any.h
@@ -70,8 +70,6 @@ struct await_when_any {
   }
 
   bool await_ready() {
-    ASYNC_CORO_ASSERT(_suspended.load(std::memory_order::relaxed) == false);
-
     const auto store_result = [this](auto& coro, auto index) -> bool {
       if (!this->_has_result.exchange(true, std::memory_order::relaxed)) {
         using result_t = decltype(coro.get());
@@ -91,12 +89,12 @@ struct await_when_any {
   template <typename U>
     requires(std::derived_from<U, base_handle>)
   void await_suspend(std::coroutine_handle<U> h) {
-    h.promise().on_suspended();
+    _suspension = h.promise().suspend(2);
 
     const auto continue_f = [&](auto& coro, auto index) {
       using result_t = decltype(coro.get());
 
-      coro.continue_with([this, h, index](auto& res) {
+      coro.continue_with([this, index](auto& res) {
         if (!_has_result.exchange(true, std::memory_order::relaxed)) {
           // continue this coro
           if constexpr (!std::is_void_v<result_t>) {
@@ -104,19 +102,14 @@ struct await_when_any {
           } else {
             new (&_result) result_type{index, std::monostate{}};
           }
-          base_handle& handle = h.promise();
-          if (_suspended.load(std::memory_order::acquire)) {
-            handle.continue_execution();
-          } else {
-            handle.plan_continue_execution();
-          }
+          _suspension.try_to_continue_on_any_thread();
         }
       });
     };
 
     call_functor(continue_f, std::index_sequence_for<TArgs...>{});
 
-    _suspended.store(true, std::memory_order::release);
+    _suspension.try_to_continue_immediately();
   }
 
   result_type await_resume() noexcept(std::is_nothrow_move_constructible_v<result_type>) {
@@ -139,11 +132,11 @@ struct await_when_any {
  private:
   std::tuple<task_launcher<TArgs>...> _launchers;
   std::tuple<task_handle<TArgs>...> _coroutines;
+  coroutine_suspender _suspension;
   union {
     result_type _result;
   };
   std::atomic_bool _has_result{false};
-  std::atomic_bool _suspended{false};
 };
 
 template <typename... TArgs>

--- a/async_coro/include/async_coro/internal/await_when_any.h
+++ b/async_coro/include/async_coro/internal/await_when_any.h
@@ -106,9 +106,9 @@ struct await_when_any {
           }
           base_handle& handle = h.promise();
           if (_suspended.load(std::memory_order::acquire)) {
-            handle.get_scheduler().continue_execution(handle);
+            handle.continue_execution();
           } else {
-            handle.get_scheduler().plan_continue_execution(handle);
+            handle.plan_continue_execution();
           }
         }
       });

--- a/async_coro/include/async_coro/internal/task_handle_awaiter.h
+++ b/async_coro/include/async_coro/internal/task_handle_awaiter.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <async_coro/base_handle.h>
+#include <async_coro/promise_result.h>
+#include <async_coro/scheduler.h>
+
+#include <atomic>
+
+namespace async_coro {
+
+template <class R>
+class task_handle;
+
+}  // namespace async_coro
+
+namespace async_coro::internal {
+
+template <class R>
+struct task_handle_awaiter {
+  task_handle<R>& _th;
+
+  explicit task_handle_awaiter(task_handle<R>& th) noexcept : _th(th) {}
+  task_handle_awaiter(const task_handle_awaiter&) = delete;
+  task_handle_awaiter(task_handle_awaiter&&) = delete;
+  ~task_handle_awaiter() noexcept = default;
+
+  bool await_ready() const noexcept { return _th.done(); }
+
+  template <typename T>
+    requires(std::derived_from<T, base_handle>)
+  void await_suspend(std::coroutine_handle<T> h) {
+    h.promise().on_suspended();
+
+    _th.continue_with([h](promise_result<R>&) {
+      h.promise().continue_execution();
+    });
+  }
+
+  R await_resume() {
+    return _th.get();
+  }
+};
+
+}  // namespace async_coro::internal

--- a/async_coro/include/async_coro/internal/task_handle_awaiter.h
+++ b/async_coro/include/async_coro/internal/task_handle_awaiter.h
@@ -4,8 +4,6 @@
 #include <async_coro/promise_result.h>
 #include <async_coro/scheduler.h>
 
-#include <atomic>
-
 namespace async_coro {
 
 template <class R>

--- a/async_coro/include/async_coro/internal/task_handle_awaiter.h
+++ b/async_coro/include/async_coro/internal/task_handle_awaiter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <async_coro/base_handle.h>
+#include <async_coro/coroutine_suspender.h>
 #include <async_coro/promise_result.h>
 #include <async_coro/scheduler.h>
 
@@ -15,8 +16,6 @@ namespace async_coro::internal {
 
 template <class R>
 struct task_handle_awaiter {
-  task_handle<R>& _th;
-
   explicit task_handle_awaiter(task_handle<R>& th) noexcept : _th(th) {}
   task_handle_awaiter(const task_handle_awaiter&) = delete;
   task_handle_awaiter(task_handle_awaiter&&) = delete;
@@ -27,16 +26,22 @@ struct task_handle_awaiter {
   template <typename T>
     requires(std::derived_from<T, base_handle>)
   void await_suspend(std::coroutine_handle<T> h) {
-    h.promise().on_suspended();
+    _suspension = h.promise().suspend(2);
 
-    _th.continue_with([h](promise_result<R>&) {
-      h.promise().continue_execution();
+    _th.continue_with([this](promise_result<R>&) {
+      _suspension.try_to_continue_on_any_thread();
     });
+
+    _suspension.try_to_continue_immediately();
   }
 
   R await_resume() {
     return _th.get();
   }
+
+ private:
+  task_handle<R>& _th;
+  coroutine_suspender _suspension;
 };
 
 }  // namespace async_coro::internal

--- a/async_coro/include/async_coro/scheduler.h
+++ b/async_coro/include/async_coro/scheduler.h
@@ -75,9 +75,10 @@ class scheduler {
    * @param coroutine_or_function The coroutine or function to be executed.
    * @return A handle to the started task.
    */
-  template <typename T>
-  auto start_task(T&& coroutine_or_function, execution_queue_mark execution_queue = execution_queues::main) {
-    return start_task(task_launcher{std::forward<T>(coroutine_or_function), execution_queue});
+  template <typename... RArgs>
+    requires(is_task_launchable<RArgs...>)
+  auto start_task(RArgs&&... launcher_args) {
+    return start_task(task_launcher{std::forward<RArgs>(launcher_args)...});
   }
 
   /**
@@ -106,7 +107,7 @@ class scheduler {
    * thread is suitable, or schedule it for later execution.
    * @param handle_impl The handle of the coroutine to continue.
    */
-  void continue_execution(base_handle& handle_impl);
+  void continue_execution(base_handle& handle_impl, internal::passkey_any<base_handle, scheduler>);
 
   /**
    * @brief Schedules a coroutine for continued execution on its assigned thread.
@@ -114,7 +115,7 @@ class scheduler {
    * the coroutine for later execution without attempting to run it immediately.
    * @param handle_impl The handle of the coroutine to schedule.
    */
-  void plan_continue_execution(base_handle& handle_impl);
+  void plan_continue_execution(base_handle& handle_impl, internal::passkey_any<base_handle, scheduler>);
 
   // Embed coroutine. Returns true if coroutine was finished
   bool on_child_coro_added(base_handle& parent, base_handle& child, internal::passkey<task_base>);

--- a/async_coro/include/async_coro/scheduler.h
+++ b/async_coro/include/async_coro/scheduler.h
@@ -17,6 +17,7 @@
 namespace async_coro {
 
 class base_handle;
+class coroutine_suspender;
 
 /**
  * @class scheduler
@@ -107,15 +108,7 @@ class scheduler {
    * thread is suitable, or schedule it for later execution.
    * @param handle_impl The handle of the coroutine to continue.
    */
-  void continue_execution(base_handle& handle_impl, internal::passkey_any<base_handle, scheduler>);
-
-  /**
-   * @brief Schedules a coroutine for continued execution on its assigned thread.
-   * @details For internal use. Unlike `continue_execution`, this method always schedules
-   * the coroutine for later execution without attempting to run it immediately.
-   * @param handle_impl The handle of the coroutine to schedule.
-   */
-  void plan_continue_execution(base_handle& handle_impl, internal::passkey_any<base_handle, scheduler>);
+  void continue_execution(base_handle& handle_impl, internal::passkey_any<coroutine_suspender, scheduler>);
 
   // Embed coroutine. Returns true if coroutine was finished
   bool on_child_coro_added(base_handle& parent, base_handle& child, internal::passkey<task_base>);

--- a/async_coro/include/async_coro/start_task.h
+++ b/async_coro/include/async_coro/start_task.h
@@ -3,6 +3,9 @@
 #include <async_coro/internal/await_start_task.h>
 #include <async_coro/task_launcher.h>
 
+#include <utility>
+
+
 namespace async_coro {
 
 /**
@@ -23,6 +26,12 @@ namespace async_coro {
 template <typename R>
 auto start_task(task_launcher<R> launcher) {
   return internal::await_start_task(std::move(launcher));
+}
+
+template <typename... RArgs>
+  requires(is_task_launchable<RArgs...>)
+auto start_task(RArgs&&... launcher_args) {
+  return internal::await_start_task(task_launcher{std::forward<RArgs>(launcher_args)...});
 }
 
 }  // namespace async_coro

--- a/async_coro/include/async_coro/start_task.h
+++ b/async_coro/include/async_coro/start_task.h
@@ -5,7 +5,6 @@
 
 #include <utility>
 
-
 namespace async_coro {
 
 /**

--- a/async_coro/include/async_coro/task_handle.h
+++ b/async_coro/include/async_coro/task_handle.h
@@ -4,6 +4,7 @@
 #include <async_coro/config.h>
 #include <async_coro/internal/passkey.h>
 #include <async_coro/internal/promise_type.h>
+#include <async_coro/internal/task_handle_awaiter.h>
 
 #include <concepts>
 #include <coroutine>
@@ -141,6 +142,10 @@ class task_handle final {
 
   void check_exception() const noexcept(!ASYNC_CORO_WITH_EXCEPTIONS) {
     _handle.promise().check_exception();
+  }
+
+  internal::task_handle_awaiter<R> coro_await_transform(base_handle&) & {
+    return internal::task_handle_awaiter<R>{*this};
   }
 
  private:

--- a/async_coro/include/async_coro/task_launcher.h
+++ b/async_coro/include/async_coro/task_launcher.h
@@ -167,4 +167,7 @@ template <typename T>
   requires(std::is_invocable_v<T> && internal::is_task_v<std::invoke_result_t<T>>)
 task_launcher(T&&, execution_queue_mark) -> task_launcher<internal::unwrap_task_t<std::invoke_result_t<T>>>;
 
+template <typename... TArgs>
+concept is_task_launchable = requires(TArgs&&... t) { task_launcher{std::forward<TArgs>(t)...}; };
+
 }  // namespace async_coro

--- a/async_coro/src/base_handle.cpp
+++ b/async_coro/src/base_handle.cpp
@@ -1,6 +1,8 @@
 #include <async_coro/base_handle.h>
 #include <async_coro/callback.h>
 #include <async_coro/config.h>
+#include <async_coro/internal/passkey.h>
+#include <async_coro/scheduler.h>
 
 #include <atomic>
 
@@ -69,6 +71,14 @@ void base_handle::inc_num_owners() noexcept {
     new_value = (expected + num_owners_step);
     ASYNC_CORO_ASSERT((expected & num_owners_mask) < num_owners_mask);
   }
+}
+
+void base_handle::continue_execution() {
+  get_scheduler().continue_execution(*this, internal::passkey{this});
+}
+
+void base_handle::plan_continue_execution() {
+  get_scheduler().plan_continue_execution(*this, internal::passkey{this});
 }
 
 }  // namespace async_coro

--- a/async_coro/src/base_handle.cpp
+++ b/async_coro/src/base_handle.cpp
@@ -73,12 +73,4 @@ void base_handle::inc_num_owners() noexcept {
   }
 }
 
-void base_handle::continue_execution() {
-  get_scheduler().continue_execution(*this, internal::passkey{this});
-}
-
-void base_handle::plan_continue_execution() {
-  get_scheduler().plan_continue_execution(*this, internal::passkey{this});
-}
-
 }  // namespace async_coro

--- a/async_coro/src/coroutine_suspender.cpp
+++ b/async_coro/src/coroutine_suspender.cpp
@@ -1,0 +1,60 @@
+#include <async_coro/base_handle.h>
+#include <async_coro/config.h>
+#include <async_coro/coroutine_suspender.h>
+#include <async_coro/internal/passkey.h>
+#include <async_coro/scheduler.h>
+
+namespace async_coro {
+
+void coroutine_suspender::try_to_continue_on_any_thread() {
+  ASYNC_CORO_ASSERT(_handle);
+
+  const auto prev_count = _suspend_count.fetch_sub(1, std::memory_order::relaxed);
+  ASYNC_CORO_ASSERT(prev_count != 0);
+
+  if (prev_count == 1) {
+    if (_handle->is_finished()) [[unlikely]] {
+      // some exception happened before callback call
+      return;
+    }
+
+    _handle->get_scheduler().continue_execution(*_handle, internal::passkey{this});
+  }
+}
+
+void coroutine_suspender::try_to_continue_immediately() {
+  ASYNC_CORO_ASSERT(_handle);
+
+  bool* was_coro_suspended = nullptr;
+
+  if (!_was_continued_immediately) {
+    _was_continued_immediately = true;
+
+    _handle->set_coroutine_state(coroutine_state::suspended);
+    was_coro_suspended = std::exchange(_handle->_was_coro_suspended, nullptr);
+    if (was_coro_suspended) {
+      ASYNC_CORO_ASSERT(*was_coro_suspended == false);
+
+      *was_coro_suspended = true;
+    }
+  }
+
+  const auto prev_count = _suspend_count.fetch_sub(1, std::memory_order::release);
+  ASYNC_CORO_ASSERT(prev_count != 0);
+
+  if (prev_count == 1) {
+    if (was_coro_suspended) {
+      // return flag as continue execution may throw exception that should be handled in finalizer
+      *was_coro_suspended = false;
+    }
+
+    if (_handle->is_finished()) [[unlikely]] {
+      // some exception happened before callback call
+      return;
+    }
+
+    _handle->get_scheduler().continue_execution(*_handle, internal::passkey{this});
+  }
+}
+
+}  // namespace async_coro

--- a/async_coro/src/coroutine_suspender.cpp
+++ b/async_coro/src/coroutine_suspender.cpp
@@ -39,7 +39,7 @@ void coroutine_suspender::try_to_continue_immediately() {
     }
   }
 
-  const auto prev_count = _suspend_count.fetch_sub(1, std::memory_order::release);
+  const auto prev_count = _suspend_count.fetch_sub(1, std::memory_order::acq_rel);
   ASYNC_CORO_ASSERT(prev_count != 0);
 
   if (prev_count == 1) {

--- a/async_coro/src/coroutine_suspender.cpp
+++ b/async_coro/src/coroutine_suspender.cpp
@@ -46,6 +46,7 @@ void coroutine_suspender::try_to_continue_immediately() {
     if (was_coro_suspended) {
       // return flag as continue execution may throw exception that should be handled in finalizer
       *was_coro_suspended = false;
+      _handle->_was_coro_suspended = was_coro_suspended;
     }
 
     if (_handle->is_finished()) [[unlikely]] {

--- a/async_coro/src/coroutine_suspender.cpp
+++ b/async_coro/src/coroutine_suspender.cpp
@@ -9,7 +9,7 @@ namespace async_coro {
 void coroutine_suspender::try_to_continue_on_any_thread() {
   ASYNC_CORO_ASSERT(_handle);
 
-  const auto prev_count = _suspend_count.fetch_sub(1, std::memory_order::relaxed);
+  const auto prev_count = _suspend_count.fetch_sub(1, std::memory_order::release);
   ASYNC_CORO_ASSERT(prev_count != 0);
 
   if (prev_count == 1) {

--- a/async_coro/src/scheduler.cpp
+++ b/async_coro/src/scheduler.cpp
@@ -53,7 +53,7 @@ bool scheduler::continue_execution_impl(base_handle& handle_impl, bool continue_
   } else if (state == coroutine_state::finished) {
     if (auto* parent = handle_impl.get_parent(); continue_parent_on_finish && parent && parent->get_coroutine_state() == coroutine_state::suspended) {
       // wake up parent coroutine
-      continue_execution(*handle_impl._parent);
+      continue_execution(*handle_impl._parent, internal::passkey{this});
     } else if (!parent) {
       // cleanup coroutine
       {
@@ -153,7 +153,7 @@ void scheduler::set_unhandled_exception_handler(unique_function<void(std::except
 }
 #endif
 
-void scheduler::continue_execution(base_handle& handle_impl) {
+void scheduler::continue_execution(base_handle& handle_impl, internal::passkey_any<base_handle, scheduler>) {
   ASYNC_CORO_ASSERT(handle_impl._execution_thread != std::thread::id{});
   ASYNC_CORO_ASSERT(handle_impl.get_coroutine_state() == coroutine_state::suspended);
 
@@ -165,7 +165,7 @@ void scheduler::continue_execution(base_handle& handle_impl) {
   }
 }
 
-void scheduler::plan_continue_execution(base_handle& handle_impl) {
+void scheduler::plan_continue_execution(base_handle& handle_impl, internal::passkey_any<base_handle, scheduler>) {
   ASYNC_CORO_ASSERT(handle_impl._execution_thread != std::thread::id{});
   ASYNC_CORO_ASSERT(handle_impl.get_coroutine_state() == coroutine_state::suspended);
 


### PR DESCRIPTION
Added ability to await another parallel tasks in task routine:
```
auto handle_double = co_await async_coro::start_task(
    []() -> async_coro::task<double> {
      co_return 3.1415;
    },
    async_coro::execution_queues::main);

double res = co_await handle_double;
```